### PR TITLE
勝敗ロジックの修正: rankの誤用を解消しIDベース判定に統一

### DIFF
--- a/DotenkoV2/Model/Game/ScoreResultData.swift
+++ b/DotenkoV2/Model/Game/ScoreResultData.swift
@@ -3,11 +3,10 @@ import Foundation
 // MARK: - Score Result Data
 /// スコア確定画面表示用のデータ構造
 struct ScoreResultData {
-    let winner: Player?
-    let loser: Player?
+    let winners: [Player] // 勝者配列（しょてんこ: 1人、バースト: 複数人、通常: 1人）
+    let losers: [Player] // 敗者配列（しょてんこ: 複数人、バースト: 1人、通常: 1人）
     let deckBottomCard: Card?
     let consecutiveCards: [Card] // 連続特殊カードのリスト
-    let winnerHand: [Card]
     let baseRate: Int
     let upRate: Int
     let finalMultiplier: Int
@@ -20,11 +19,10 @@ struct ScoreResultData {
     let burstPlayerId: String?
     
     init(
-        winner: Player?,
-        loser: Player?,
+        winners: [Player] = [],
+        losers: [Player] = [],
         deckBottomCard: Card?,
         consecutiveCards: [Card] = [],
-        winnerHand: [Card] = [],
         baseRate: Int,
         upRate: Int,
         finalMultiplier: Int,
@@ -34,11 +32,10 @@ struct ScoreResultData {
         shotenkoWinnerId: String? = nil,
         burstPlayerId: String? = nil
     ) {
-        self.winner = winner
-        self.loser = loser
+        self.winners = winners
+        self.losers = losers
         self.deckBottomCard = deckBottomCard
         self.consecutiveCards = consecutiveCards
-        self.winnerHand = winnerHand
         self.baseRate = baseRate
         self.upRate = upRate
         self.finalMultiplier = finalMultiplier

--- a/DotenkoV2/View/Game/GameMainView.swift
+++ b/DotenkoV2/View/Game/GameMainView.swift
@@ -84,11 +84,10 @@ struct GameMainView: View {
             // スコア確定画面
             if viewModel.showScoreResult, let scoreData = viewModel.scoreResultData {
                 ScoreResultView(
-                    winner: scoreData.winner,
-                    loser: scoreData.loser,
+                    winners: scoreData.winners,
+                    losers: scoreData.losers,
                     deckBottomCard: scoreData.deckBottomCard,
                     consecutiveCards: scoreData.consecutiveCards,
-                    winnerHand: scoreData.winnerHand,
                     baseRate: scoreData.baseRate,
                     upRate: scoreData.upRate,
                     finalMultiplier: scoreData.finalMultiplier,
@@ -97,7 +96,9 @@ struct GameMainView: View {
                     isBurstRound: scoreData.isBurstRound,
                     shotenkoWinnerId: scoreData.shotenkoWinnerId,
                     burstPlayerId: scoreData.burstPlayerId,
-                    onOKAction: viewModel.onScoreResultOK
+                    onOKAction: {
+                        viewModel.onScoreResultOK()
+                    }
                 )
             }
             

--- a/DotenkoV2/View/Game/InterimResultView.swift
+++ b/DotenkoV2/View/Game/InterimResultView.swift
@@ -117,12 +117,22 @@ struct InterimResultView: View {
             }
         }
         
-        // 通常のどてんこの場合
-        if player.rank == 1 {
-            return roundScore
-        } else if player.rank == viewModel.players.count {
-            return -roundScore
+        // 通常のどてんこの場合（IDベースのみ）
+        if let winnerId = viewModel.revengeManager.dotenkoWinnerId {
+            if player.id == winnerId {
+                // 勝者：スコアを獲得
+                return roundScore
+            } else if let lastCardPlayerId = viewModel.lastCardPlayerId,
+                      player.id == lastCardPlayerId {
+                // 敗者（場のカードを出した人）：スコアを失う
+                return -roundScore
+            } else {
+                // その他のプレイヤー：変動なし
+                return 0
+            }
         } else {
+            // 勝者IDが不明な場合はスコア変動なし
+            print("⚠️ 通常どてんこの勝者IDが不明のため、スコア変動なし")
             return 0
         }
     }

--- a/DotenkoV2/View/Game/ScoreResultView.swift
+++ b/DotenkoV2/View/Game/ScoreResultView.swift
@@ -23,11 +23,10 @@ struct ScoreResultView: View {
     }
     
     // MARK: - Input Properties
-    let winner: Player?
-    let loser: Player?
+    let winners: [Player] // 勝者配列
+    let losers: [Player] // 敗者配列
     let deckBottomCard: Card?
     let consecutiveCards: [Card]
-    let winnerHand: [Card]
     let baseRate: Int
     let upRate: Int
     let finalMultiplier: Int
@@ -42,16 +41,16 @@ struct ScoreResultView: View {
     @StateObject private var viewModel: ScoreResultViewModel
     
     // MARK: - Initialization
-    init(winner: Player?, loser: Player?, deckBottomCard: Card?, consecutiveCards: [Card], 
-         winnerHand: [Card], baseRate: Int, upRate: Int, finalMultiplier: Int, totalScore: Int,
+    init(winners: [Player] = [], losers: [Player] = [], deckBottomCard: Card?, consecutiveCards: [Card], 
+         baseRate: Int, upRate: Int, finalMultiplier: Int, totalScore: Int,
          isShotenkoRound: Bool = false, isBurstRound: Bool = false,
          shotenkoWinnerId: String? = nil, burstPlayerId: String? = nil,
          onOKAction: @escaping () -> Void) {
-        self.winner = winner
-        self.loser = loser
+        
+        self.winners = winners
+        self.losers = losers
         self.deckBottomCard = deckBottomCard
         self.consecutiveCards = consecutiveCards
-        self.winnerHand = winnerHand
         self.baseRate = baseRate
         self.upRate = upRate
         self.finalMultiplier = finalMultiplier
@@ -63,8 +62,8 @@ struct ScoreResultView: View {
         self.onOKAction = onOKAction
         
         self._viewModel = StateObject(wrappedValue: ScoreResultViewModel(
-            winner: winner,
-            loser: loser,
+            winners: winners,
+            losers: losers,
             deckBottomCard: deckBottomCard,
             consecutiveCards: consecutiveCards,
             baseRate: baseRate,

--- a/DotenkoV2/ViewModel/GameScoreCalculationManager.swift
+++ b/DotenkoV2/ViewModel/GameScoreCalculationManager.swift
@@ -332,8 +332,8 @@ class GameScoreCalculationManager: ObservableObject {
         completion()
     }
     
-    /// プレイヤーにスコアを適用
-    func applyScoreToPlayers(players: inout [Player], isShotenkoRound: Bool, isBurst: Bool, shotenkoWinnerId: String?, burstPlayerId: String?) {
+    /// プレイヤーにスコアを適用（IDベース統一）
+    func applyScoreToPlayers(players: inout [Player], isShotenkoRound: Bool, isBurst: Bool, shotenkoWinnerId: String?, burstPlayerId: String?, dotenkoWinnerId: String?, lastCardPlayerId: String?) {
         // しょてんこの場合の特別計算
         if isShotenkoRound, let shotenkoWinnerId = shotenkoWinnerId {
             applyShotenkoScore(players: &players, winnerId: shotenkoWinnerId)
@@ -346,21 +346,8 @@ class GameScoreCalculationManager: ObservableObject {
             return
         }
         
-        // 通常のどてんこの場合
-        for index in players.indices {
-            let player = players[index]
-            
-            if player.rank == 1 {
-                // 勝者：スコアを獲得
-                players[index].score += roundScore
-                print("🏆 \(player.name) がスコア獲得: +\(roundScore)")
-            } else if player.rank == players.count {
-                // 敗者：スコアを失う
-                players[index].score -= roundScore
-                print("💀 \(player.name) がスコア失失: -\(roundScore)")
-            }
-            // 中間順位は変動なし
-        }
+        // 通常のどてんこの場合（IDベース統一）
+        applyNormalDotenkoScore(players: &players, winnerId: dotenkoWinnerId, loserId: lastCardPlayerId)
     }
     
     /// しょてんこのスコア計算
@@ -400,6 +387,41 @@ class GameScoreCalculationManager: ObservableObject {
                 players[index].score += roundScore
                 print("🏆 \(players[index].name) がバーストでスコア獲得: +\(roundScore)")
             }
+        }
+    }
+    
+    /// 通常のどてんこのスコア計算（IDベース）
+    private func applyNormalDotenkoScore(players: inout [Player], winnerId: String?, loserId: String?) {
+        guard let winnerId = winnerId else {
+            print("⚠️ 通常どてんこの勝者IDが見つかりません - スコア適用をスキップ")
+            return
+        }
+        
+        guard let loserId = loserId else {
+            print("⚠️ 通常どてんこの敗者IDが見つかりません - スコア適用をスキップ")
+            return
+        }
+        
+        // 勝者にスコアを加算
+        if let winnerIndex = players.firstIndex(where: { $0.id == winnerId }) {
+            players[winnerIndex].score += roundScore
+            print("🏆 \(players[winnerIndex].name) がどてんこでスコア獲得: +\(roundScore)")
+        } else {
+            print("⚠️ 勝者プレイヤーが見つかりません: \(winnerId)")
+        }
+        
+        // 敗者からスコアを減算
+        if let loserIndex = players.firstIndex(where: { $0.id == loserId }) {
+            players[loserIndex].score -= roundScore
+            print("💀 \(players[loserIndex].name) がどてんこでスコア失失: -\(roundScore)")
+        } else {
+            print("⚠️ 敗者プレイヤーが見つかりません: \(loserId)")
+        }
+        
+        // その他のプレイヤーは変動なし
+        let otherPlayers = players.filter { $0.id != winnerId && $0.id != loserId }
+        for player in otherPlayers {
+            print("➖ \(player.name) はスコア変動なし")
         }
     }
     

--- a/DotenkoV2/ViewModel/GameViewModel.swift
+++ b/DotenkoV2/ViewModel/GameViewModel.swift
@@ -1425,7 +1425,7 @@ class GameViewModel: ObservableObject {
         // 勝敗設定（しょてんこ・バーストの場合は既に設定済み、通常のどてんこの場合は設定）
         if !isShotenkoRound && !isBurst {
             // 通常のどてんこの場合の勝敗設定
-            setDotenkoVictoryRanks()
+            recordDotenkoWinnerAndLoser()
         }
         
         print("🎮 ゲーム終了 - どてんこ勝利確定")
@@ -1434,8 +1434,8 @@ class GameViewModel: ObservableObject {
         startScoreCalculation()
     }
     
-    /// 通常のどてんこ勝敗設定（IDベースのみ）
-    private func setDotenkoVictoryRanks() {
+    /// 通常のどてんこ勝者・敗者を記録（IDベースのみ）
+    private func recordDotenkoWinnerAndLoser() {
         guard let winnerId = revengeManager.dotenkoWinnerId else { return }
         
         print("🏆 通常どてんこ勝者設定: \(players.first(where: { $0.id == winnerId })?.name ?? "不明")")

--- a/DotenkoV2/ViewModel/GameViewModel.swift
+++ b/DotenkoV2/ViewModel/GameViewModel.swift
@@ -1434,32 +1434,22 @@ class GameViewModel: ObservableObject {
         startScoreCalculation()
     }
     
-    /// 通常のどてんこ勝敗設定
+    /// 通常のどてんこ勝敗設定（IDベースのみ）
     private func setDotenkoVictoryRanks() {
         guard let winnerId = revengeManager.dotenkoWinnerId else { return }
         
-        // 勝者の設定
-        if let winnerIndex = players.firstIndex(where: { $0.id == winnerId }) {
-            players[winnerIndex].rank = 1
-            print("🏆 どてんこ勝者: \(players[winnerIndex].name)")
+        print("🏆 通常どてんこ勝者設定: \(players.first(where: { $0.id == winnerId })?.name ?? "不明")")
+        
+        // 場のカードを出したプレイヤーを敗者とする（正しい実装）
+        guard let loserId = lastCardPlayerId else {
+            print("⚠️ 場のカードを出したプレイヤーIDが見つかりません")
+            return
         }
         
-        // 場のカードを出したプレイヤーを敗者に設定
-        // 現在のターンプレイヤーが場のカードを出したプレイヤーと仮定
-        if let currentTurnPlayer = getCurrentTurnPlayer(),
-           currentTurnPlayer.id != winnerId {
-            if let loserIndex = players.firstIndex(where: { $0.id == currentTurnPlayer.id }) {
-                players[loserIndex].rank = players.count // 最下位
-                print("💀 敗者（場のカードを出した人）: \(players[loserIndex].name)")
-            }
-        }
+        print("💀 通常どてんこ敗者設定: \(players.first(where: { $0.id == loserId })?.name ?? "不明")（場のカードを出した人）")
         
-        // その他のプレイヤーは中間順位
-        for index in players.indices {
-            if players[index].rank == 0 { // まだ順位が決まっていないプレイヤー
-                players[index].rank = 2
-            }
-        }
+        // 注意：rankは順位専用のため、勝敗判定では使用しない
+        // 実際の勝敗判定は全てIDベースで行う
     }
     
     /// リベンジボタンを表示すべきかチェック
@@ -1547,17 +1537,12 @@ class GameViewModel: ObservableObject {
         isShotenkoRound = true
         shotenkoWinnerId = playerId
         players[playerIndex].dtnk = true
-        players[playerIndex].rank = 1 // 勝者
-        
-        // その他全員を敗者に設定
-        for index in players.indices {
-            if players[index].id != playerId {
-                players[index].rank = players.count // 最下位
-            }
-        }
         
         print("🏆 しょてんこ勝者: \(players[playerIndex].name)")
         print("💀 しょてんこ敗者: その他全員")
+        
+        // 注意：rankは順位専用のため、勝敗判定では使用しない
+        // 実際の勝敗判定は全てIDベースで行う
         
         // しょてんこ宣言時に即座に全プレイヤーの処理を停止
         stopAllPlayerActions()
@@ -1582,29 +1567,20 @@ class GameViewModel: ObservableObject {
         // バースト状態を設定
         isBurst = true
         burstPlayerId = playerId
-        players[playerIndex].rank = players.count // 敗者（最下位）
-        
-        // その他全員を勝者に設定
-        for index in players.indices {
-            if players[index].id != playerId {
-                players[index].rank = 1 // 勝者
-            }
-                }
         
         print("💀 バースト敗者: \(players[playerIndex].name)")
         print("🏆 バースト勝者: その他全員")
         
-        // バースト発生アナウンス
-        announcementEffectManager.showAnnouncementMessage(
-            title: "バースト発生！",
-            subtitle: "\(players[playerIndex].name) の敗北"
-        ) {
-            // バーストの場合はチャレンジゾーンをスキップして直接スコア確定
-            self.gamePhase = .finished
-            print("🎮 ラウンド終了 - バーストによる勝敗確定（チャレンジゾーンスキップ）")
-            
-            // スコア計算を開始（正しい流れでスコア確定画面を表示）
-            self.startScoreCalculation()
+        // 注意：rankは順位専用のため、勝敗判定では使用しない
+        // 実際の勝敗判定は全てIDベースで行う
+        
+        // バーストアニメーションを表示
+        let playerName = players[playerIndex].name
+        announcementEffectManager.showDeclarationAnimation(type: .dotenko, playerName: playerName) {
+            // アニメーション完了後に直接スコア確定に進む（チャレンジゾーンスキップ）
+            DispatchQueue.main.async {
+                self.finalizeDotenko()
+            }
         }
     }
     
@@ -1699,7 +1675,9 @@ class GameViewModel: ObservableObject {
             isShotenkoRound: isShotenkoRound,
             isBurst: isBurst,
             shotenkoWinnerId: shotenkoWinnerId,
-            burstPlayerId: burstPlayerId
+            burstPlayerId: burstPlayerId,
+            dotenkoWinnerId: revengeManager.dotenkoWinnerId, // 通常のどてんこ勝者ID
+            lastCardPlayerId: lastCardPlayerId // 場のカードを出したプレイヤーID
         )
         
         print("💰 スコア計算完了 - 自動遷移開始")
@@ -1753,32 +1731,43 @@ class GameViewModel: ObservableObject {
     
     /// プレイヤーにスコアを適用
     private func applyScoreToPlayers() {
-        // しょてんこの場合の特別計算
+        // しょてんこの場合の特別計算（IDベース）
         if isShotenkoRound, let shotenkoWinnerId = shotenkoWinnerId {
             applyShotenkoScore(winnerId: shotenkoWinnerId)
             return
         }
         
-        // バーストの場合の特別計算
+        // バーストの場合の特別計算（IDベース）
         if isBurst, let burstPlayerId = burstPlayerId {
             applyBurstScore(burstPlayerId: burstPlayerId)
             return
         }
         
-        // 通常のどてんこの場合
+        // 通常のどてんこの場合（IDベースのみ）
+        guard let winnerId = revengeManager.dotenkoWinnerId else {
+            print("⚠️ 通常どてんこの勝者IDが見つかりません")
+            return
+        }
+        
+        // 場のカードを出したプレイヤーを敗者とする（正しい実装）
+        guard let loserId = lastCardPlayerId else {
+            print("⚠️ 場のカードを出したプレイヤーIDが見つかりません")
+            return
+        }
+        
         for index in players.indices {
             let player = players[index]
             
-            if player.rank == 1 {
+            if player.id == winnerId {
                 // 勝者：スコアを獲得
                 players[index].score += roundScore
                 print("🏆 \(player.name) がスコア獲得: +\(roundScore)")
-            } else if player.rank == players.count {
-                // 敗者：スコアを失う
+            } else if player.id == loserId {
+                // 敗者（場のカードを出した人）：スコアを失う
                 players[index].score -= roundScore
                 print("💀 \(player.name) がスコア失失: -\(roundScore)")
             }
-            // 中間順位は変動なし
+            // その他のプレイヤーは変動なし
         }
     }
     

--- a/DotenkoV2/ViewModel/ScoreResultViewModel.swift
+++ b/DotenkoV2/ViewModel/ScoreResultViewModel.swift
@@ -72,8 +72,8 @@ class ScoreResultViewModel: ObservableObject {
     @Published var isReversed: Bool = false
     @Published var showReversalAnimation: Bool = false
     @Published var reversalAnimationPhase: Int = 0
-    @Published var currentWinner: Player?
-    @Published var currentLoser: Player?
+    @Published var currentWinner: Player? // UI表示用（代表勝者）
+    @Published var currentLoser: Player? // UI表示用（代表敗者）
     
     // MARK: - Private Properties
     private var currentRevealIndex: Int = 0
@@ -81,9 +81,9 @@ class ScoreResultViewModel: ObservableObject {
     private var needsAdditionalCard: Bool = false
     private var additionalCards: [Card] = []
     
-    // 入力データ
-    private let winner: Player?
-    private let loser: Player?
+    // 入力データ（配列対応）
+    private let winners: [Player] // 勝者配列
+    private let losers: [Player] // 敗者配列
     private let deckBottomCard: Card?
     private let consecutiveCards: [Card]
     private let baseRate: Int
@@ -106,12 +106,12 @@ class ScoreResultViewModel: ObservableObject {
     }
     
     // MARK: - Initialization
-    init(winner: Player?, loser: Player?, deckBottomCard: Card?, consecutiveCards: [Card], 
+    init(winners: [Player] = [], losers: [Player] = [], deckBottomCard: Card?, consecutiveCards: [Card], 
          baseRate: Int, upRate: Int, finalMultiplier: Int, totalScore: Int,
          isShotenkoRound: Bool = false, isBurstRound: Bool = false,
          shotenkoWinnerId: String? = nil, burstPlayerId: String? = nil) {
-        self.winner = winner
-        self.loser = loser
+        self.winners = winners
+        self.losers = losers
         self.deckBottomCard = deckBottomCard
         self.consecutiveCards = consecutiveCards
         self.baseRate = baseRate
@@ -139,30 +139,25 @@ class ScoreResultViewModel: ObservableObject {
     private func setupPlayerStates() {
         // バーストの場合：バーストしたプレイヤーをLoserとして表示
         if isBurstRound, let burstPlayerId = burstPlayerId {
-            // バーストしたプレイヤーを見つけてLoserに設定
-            if let burstPlayer = [winner, loser].compactMap({ $0 }).first(where: { $0.id == burstPlayerId }) {
-                currentWinner = nil
-                currentLoser = burstPlayer
-            } else {
-                currentWinner = winner
-                currentLoser = loser
-            }
+            // バーストしたプレイヤーを敗者として設定
+            currentLoser = losers.first { $0.id == burstPlayerId }
+            // 勝者は複数いるので代表として最初の人を表示
+            currentWinner = winners.first
+            print("💥 バースト表示設定: 敗者=\(currentLoser?.name ?? "nil"), 勝者代表=\(currentWinner?.name ?? "nil")")
         }
         // しょてんこの場合：しょてんこしたプレイヤーをWinnerとして表示
         else if isShotenkoRound, let shotenkoWinnerId = shotenkoWinnerId {
-            // しょてんこしたプレイヤーを見つけてWinnerに設定
-            if let shotenkoPlayer = [winner, loser].compactMap({ $0 }).first(where: { $0.id == shotenkoWinnerId }) {
-                currentWinner = shotenkoPlayer
-                currentLoser = nil
-            } else {
-                currentWinner = winner
-                currentLoser = loser
-            }
+            // しょてんこしたプレイヤーを勝者として設定
+            currentWinner = winners.first { $0.id == shotenkoWinnerId }
+            // 敗者は複数いるので代表として最初の人を表示
+            currentLoser = losers.first
+            print("🎊 しょてんこ表示設定: 勝者=\(currentWinner?.name ?? "nil"), 敗者代表=\(currentLoser?.name ?? "nil")")
         }
         // 通常のどてんこの場合
         else {
-            currentWinner = winner
-            currentLoser = loser
+            currentWinner = winners.first
+            currentLoser = losers.first
+            print("🎯 通常どてんこ表示設定: 勝者=\(currentWinner?.name ?? "nil"), 敗者=\(currentLoser?.name ?? "nil")")
         }
         
         currentUpRate = upRate


### PR DESCRIPTION
- GameScoreCalculationManager: 勝者・敗者特定をIDベースに変更
- しょてんこ対応: 勝者1人・敗者複数の正確な特定
- バースト対応: 敗者1人・勝者複数の正確な特定
- スコア適用処理: 全パターンでIDベース判定に統一
- InterimResultView: スコア変更計算をIDベースに変更
- Player.rankを本来のスコア順位用途に整理
- 互換性維持: 既存rank設定は互換性のため保持