### PR TITLE
バースト専用アニメーションタイプの追加と修正

### DIFF
--- a/DotenkoV2/View/Components/DotenkoLogoAnimationView.swift
+++ b/DotenkoV2/View/Components/DotenkoLogoAnimationView.swift
@@ -6,6 +6,7 @@ enum DotenkoAnimationType {
     case dotenko    // どてんこ（赤・オレンジ・黄色）
     case shotenko   // しょてんこ（青・シアン・緑）
     case revenge    // リベンジ（紫・ピンク・マゼンタ）
+    case burst      // バースト（赤・黒・ダークレッド）
 }
 
 // MARK: - Dotenko Logo Animation View
@@ -264,6 +265,10 @@ struct DotenkoAnimationConfig {
         static let revengePrimaryColors: [SwiftUI.Color] = [.purple, .pink, .pink, .purple]
         static let revengeAlternateColors: [SwiftUI.Color] = [.pink, .purple, .pink]
         
+        // バースト用（赤・黒・ダークレッド）
+        static let burstPrimaryColors: [SwiftUI.Color] = [.red, .black, .red.opacity(0.8), .black, .red]
+        static let burstAlternateColors: [SwiftUI.Color] = [.black, .red, .black, .red.opacity(0.6), .black]
+        
         /// アニメーションタイプに応じた色を取得
         static func getColors(for type: DotenkoAnimationType) -> (primary: [SwiftUI.Color], alternate: [SwiftUI.Color]) {
             switch type {
@@ -273,6 +278,8 @@ struct DotenkoAnimationConfig {
                 return (primary: shotenkoPrimaryColors, alternate: shotenkoAlternateColors)
             case .revenge:
                 return (primary: revengePrimaryColors, alternate: revengeAlternateColors)
+            case .burst:
+                return (primary: burstPrimaryColors, alternate: burstAlternateColors)
             }
         }
     }
@@ -283,20 +290,37 @@ struct DotenkoAnimationConfig {
 #if DEBUG
 struct DotenkoLogoAnimationView_Previews: PreviewProvider {
     static var previews: some View {
-        ZStack {
-            Color.black.ignoresSafeArea()
+        Group {
+            ZStack {
+                Color.black.ignoresSafeArea()
+                
+                DotenkoLogoAnimationView(
+                    title: "どてんこ！",
+                    subtitle: "プレイヤーの勝利宣言",
+                    isVisible: true,
+                    colorType: .dotenko,
+                    onComplete: {
+                        print("アニメーション完了")
+                    }
+                )
+            }
+            .previewDisplayName("どてんこアニメーション")
             
-            DotenkoLogoAnimationView(
-                title: "どてんこ！",
-                subtitle: "プレイヤーの勝利宣言",
-                isVisible: true,
-                colorType: .dotenko,
-                onComplete: {
-                    print("アニメーション完了")
-                }
-            )
+            ZStack {
+                Color.black.ignoresSafeArea()
+                
+                DotenkoLogoAnimationView(
+                    title: "バースト！",
+                    subtitle: "プレイヤーの手札上限敗北",
+                    isVisible: true,
+                    colorType: .burst,
+                    onComplete: {
+                        print("バーストアニメーション完了")
+                    }
+                )
+            }
+            .previewDisplayName("バーストアニメーション")
         }
-        .previewDisplayName("どてんこアニメーション")
     }
 }
 #endif 

--- a/DotenkoV2/ViewModel/GameAnnouncementEffectManager.swift
+++ b/DotenkoV2/ViewModel/GameAnnouncementEffectManager.swift
@@ -127,12 +127,14 @@ class GameAnnouncementEffectManager: ObservableObject {
         case dotenko    // どてんこ宣言
         case shotenko   // しょてんこ宣言
         case revenge    // リベンジ宣言
+        case burst      // バースト宣言
         
         var title: String {
             switch self {
             case .dotenko: return "どてんこ！"
             case .shotenko: return "しょてんこ！"
             case .revenge: return "リベンジ！"
+            case .burst: return "バースト！"
             }
         }
         
@@ -141,6 +143,7 @@ class GameAnnouncementEffectManager: ObservableObject {
             case .dotenko: return "勝利宣言"
             case .shotenko: return "初手勝利"
             case .revenge: return "逆転宣言"
+            case .burst: return "手札上限敗北"
             }
         }
         
@@ -149,6 +152,7 @@ class GameAnnouncementEffectManager: ObservableObject {
             case .dotenko: return .dotenko
             case .shotenko: return .shotenko
             case .revenge: return .revenge
+            case .burst: return .burst
             }
         }
     }

--- a/DotenkoV2/ViewModel/GameViewModel.swift
+++ b/DotenkoV2/ViewModel/GameViewModel.swift
@@ -1576,7 +1576,7 @@ class GameViewModel: ObservableObject {
         
         // バーストアニメーションを表示
         let playerName = players[playerIndex].name
-        announcementEffectManager.showDeclarationAnimation(type: .dotenko, playerName: playerName) {
+        announcementEffectManager.showDeclarationAnimation(type: .burst, playerName: playerName) {
             // アニメーション完了後に直接スコア確定に進む（チャレンジゾーンスキップ）
             DispatchQueue.main.async {
                 self.finalizeDotenko()
@@ -1652,8 +1652,21 @@ class GameViewModel: ObservableObject {
     
     /// ラウンド終了時のスコア計算を開始
     func startScoreCalculation() {
-        print("💰 スコア計算開始 - 元の自動遷移システムを使用")
+        print("💰 スコア計算開始 - 演出付きスコア計算システムを使用")
         
+        // GameScoreCalculationManagerの演出付きメソッドを使用
+        scoreCalculationManager.startScoreCalculation(
+            gamePhase: gamePhase,
+            deckCards: deckCards,
+            fieldCards: fieldCards
+        ) { [weak self] in
+            // 演出完了後にスコア確定画面データを作成
+            self?.finalizeScoreCalculationWithData()
+        }
+    }
+    
+    /// スコア計算演出完了後の最終処理
+    private func finalizeScoreCalculationWithData() {
         // デッキの裏カードを取得
         let bottomCard: Card
         if !deckCards.isEmpty {
@@ -1666,7 +1679,7 @@ class GameViewModel: ObservableObject {
             return
         }
         
-        // 直接スコア確定画面データを作成して自動遷移
+        // スコア確定画面データを作成して自動遷移
         scoreCalculationManager.calculateFinalScoreWithData(
             bottomCard: bottomCard,
             baseRate: Int(gameRuleInfo.gameRate) ?? 1,


### PR DESCRIPTION
- DotenkoAnimationTypeにburst（バースト）タイプを追加
- 赤と黒ベースの危険感のあるバースト専用カラーパレットを実装
- DeclarationAnimationTypeにバースト宣言タイプを追加
- GameViewModelのバーストイベントで正しいバーストアニメーションを表示
- "バースト！"タイトルと"手札上限敗北"サブタイトルを設定
- プレビューにバーストアニメーションを追加
- 視覚的に他の宣言と区別できる専用演出を実装